### PR TITLE
DX-1550 event implementation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Lint
 ----
 _phpstan_ using our `composer script`:
 ```bash
-compser phpstan
+composer phpstan
 ```
 
 Generate Documentation

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   },
   "require-dev": {
     "guzzlehttp/psr7": "^1.7.0",
+    "mockery/mockery": "^1.4",
     "php-coveralls/php-coveralls": "^2.4",
     "php-http/guzzle7-adapter": "^0.1.1",
     "phpdocumentor/phpdocumentor": "^3.0.0",

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -2,21 +2,15 @@
 
 namespace ShipEngine\Message\Events;
 
-use ShipEngine\Model\Address\Address;
 use DateInterval;
-use PHPUnit\Framework\TestCase;
+use \Mockery\Adapter\Phpunit\MockeryTestCase;
 use ShipEngine\Message\Events\RequestSentEvent;
 use ShipEngine\Message\Events\ShipEngineEventListener;
+use ShipEngine\Model\Address\Address;
 use ShipEngine\ShipEngine;
-use ShipEngine\ShipEngineClient;
 use ShipEngine\Util\Constants\Endpoints;
 use ShipEngine\Util\Constants\RPCMethods;
 use ShipEngine\ShipEngineConfig;
-
-class Foo {
-    function foo() { return 42; }
-    function bar() { return $this->foo(); }
-}
 
 /**
  * @covers \ShipEngine\Message\Events\RequestSentEvent
@@ -28,104 +22,37 @@ class Foo {
  * https://github.com/ShipEngine/shipengine-js/blob/6363c722569436a69c4ffa7fe5f1c51e17c12e8d/test/specs/events.spec.js#L9-L37
  * 
  */
-final class RequestSentEventTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
+final class RequestSentEventTest extends MockeryTestCase
 {
-    /**
-     * @var ShipEngine
-     */
-    private static ShipEngine $shipengine;
-    /**
-     * @var Object
-     */
-    private static Object $event_listener;
-
-    // public function tearDown() {
-    //     \Mockery::close();
-    // }
-
-    /**
-     *
-     */
-    public static function setUpBeforeClass(): void
+    public function testRequestSent(): void
     {
-        self::$event_listener = new ShipEngineEventListener;
-        self::$shipengine = new ShipEngine(
+        // PHPUnit cannot mock final classes, so we'll use Mockery, which
+        // will create a "proxied partial test double."
+        // See: http://docs.mockery.io/en/latest/reference/final_methods_classes.html
+        $spy = \Mockery::spy('ShipEngineEventListener');
+        
+        $shipengine = new ShipEngine(
             array(
                 'api_key' => 'baz',
                 'base_url' => Endpoints::TEST_RPC_URL,
-                'page_size' => 75,
-                'retries' => 1,
                 'timeout' => new DateInterval('PT15000S'),
-                'event_listener' => self::$event_listener
+                'event_listener' => $spy
             )
         );
-    }
 
-    public function testRequestSent()
-    {
         $good_address = new Address(
             array(
-                'street' => array('4 Jersey St', 'ste 200'),
-                'city_locality' => 'Boston',
-                'state_province' => 'MA',
-                'postal_code' => '02215',
+                'street' => array('11222 Washington Pl'),
+                'city_locality' => 'Culver City',
+                'state_province' => 'CA',
+                'postal_code' => '90230',
                 'country_code' => 'US',
             )
         );
-        
-        // NOTE:NW `PHPUnit\Framework\MockObject\ClassIsFinalException:
-        // Class "ShipEngine\Message\Events\ShipEngineEventListener" is declared
-        //  "final" and cannot be mocked
-        // See: http://docs.mockery.io/en/latest/reference/final_methods_classes.html`
-        // Solution: Use \Mockery with an instantiated class argument, a.k.a
-        // "proxied partial test doubles."
-        $foo = \Mockery::mock("Foo");
-        // Passes
-        $foo->shouldReceive('foo')
-        ->once();
-        $foo->foo();
-
-        $temp = new Foo;
-        $foo = \Mockery::mock($temp);
-        // Passes
-        $foo->shouldReceive('foo')
-        ->once();
-        $foo->foo();
-        
-        # $mock_request = self::$shipengine->validateAddress($good_address);
-
-        $client = new ShipEngineClient();
-        $foo = \Mockery::mock($client);
-        // Fails, curiously.
-        //
-        // TODO:NW Wire this up successfully.
-        //
-        // $foo->shouldReceive('request')
-        //->once();
-        $api_response = $client->request(
-            RPCMethods::ADDRESS_VALIDATE,
-            new ShipEngineConfig(array(
-                'api_key' => 'baz',
-                'base_url' => Endpoints::TEST_RPC_URL,
-                'page_size' => 75,
-                'retries' => 1,
-                'timeout' => new DateInterval('PT15000S'),
-                'event_listener' => self::$event_listener
-            )),
-            $good_address->jsonSerialize()
-        );
-
-        $listener = new ShipEngineEventListener();
-        // Ultimately, we want:
-        // $spy = \Mockery::spy(self::$event_listener);
-        // OR
-        // $foo = \Mockery::mock($listener);
-        // $foo->shouldReceive('onRequestSent')
-        // ->once();
-        # $mock_request = self::$shipengine->validateAddress($good_address);
-
-        // assert
-        //\Mockery::close();
-    }
     
+        $shipengine->validateAddress($good_address);
+
+        $spy->shouldHaveReceived('onRequestSent')->once();
+        $spy->shouldNotReceive('arbitraryValue');
+    }
 }

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace ShipEngine\Message\Events;
+
+use ShipEngine\Model\Address\Address;
+use DateInterval;
+use PHPUnit\Framework\TestCase;
+use ShipEngine\Message\Events\RequestSentEvent;
+use ShipEngine\Message\Events\ShipEngineEventListener;
+use ShipEngine\ShipEngine;
+use ShipEngine\ShipEngineClient;
+use ShipEngine\Util\Constants\Endpoints;
+use ShipEngine\Util\Constants\RPCMethods;
+use ShipEngine\ShipEngineConfig;
+
+class Foo {
+    function foo() { return 42; }
+    function bar() { return $this->foo(); }
+}
+
+/**
+ * @covers \ShipEngine\Message\Events\RequestSentEvent
+ * 
+ * To run in isolation:
+ *   ./vendor/bin/phpunit --process-isolation --filter RequestSentEventTest
+ * 
+ * This test should mimic:
+ * https://github.com/ShipEngine/shipengine-js/blob/6363c722569436a69c4ffa7fe5f1c51e17c12e8d/test/specs/events.spec.js#L9-L37
+ * 
+ */
+final class RequestSentEventTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
+{
+    /**
+     * @var ShipEngine
+     */
+    private static ShipEngine $shipengine;
+    /**
+     * @var Object
+     */
+    private static Object $event_listener;
+
+    // public function tearDown() {
+    //     \Mockery::close();
+    // }
+
+    /**
+     *
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$event_listener = new ShipEngineEventListener;
+        self::$shipengine = new ShipEngine(
+            array(
+                'api_key' => 'baz',
+                'base_url' => Endpoints::TEST_RPC_URL,
+                'page_size' => 75,
+                'retries' => 1,
+                'timeout' => new DateInterval('PT15000S'),
+                'event_listener' => self::$event_listener
+            )
+        );
+    }
+
+    public function testRequestSent()
+    {
+        $good_address = new Address(
+            array(
+                'street' => array('4 Jersey St', 'ste 200'),
+                'city_locality' => 'Boston',
+                'state_province' => 'MA',
+                'postal_code' => '02215',
+                'country_code' => 'US',
+            )
+        );
+        
+        // NOTE:NW `PHPUnit\Framework\MockObject\ClassIsFinalException:
+        // Class "ShipEngine\Message\Events\ShipEngineEventListener" is declared
+        //  "final" and cannot be mocked
+        // See: http://docs.mockery.io/en/latest/reference/final_methods_classes.html`
+        // Solution: Use \Mockery with an instantiated class argument, a.k.a
+        // "proxied partial test doubles."
+        $foo = \Mockery::mock("Foo");
+        // Passes
+        $foo->shouldReceive('foo')
+        ->once();
+        $foo->foo();
+
+        $temp = new Foo;
+        $foo = \Mockery::mock($temp);
+        // Passes
+        $foo->shouldReceive('foo')
+        ->once();
+        $foo->foo();
+        
+        # $mock_request = self::$shipengine->validateAddress($good_address);
+
+        $client = new ShipEngineClient();
+        $foo = \Mockery::mock($client);
+        // Fails, curiously.
+        //
+        // TODO:NW Wire this up successfully.
+        //
+        // $foo->shouldReceive('request')
+        //->once();
+        $api_response = $client->request(
+            RPCMethods::ADDRESS_VALIDATE,
+            new ShipEngineConfig(array(
+                'api_key' => 'baz',
+                'base_url' => Endpoints::TEST_RPC_URL,
+                'page_size' => 75,
+                'retries' => 1,
+                'timeout' => new DateInterval('PT15000S'),
+                'event_listener' => self::$event_listener
+            )),
+            $good_address->jsonSerialize()
+        );
+
+        $listener = new ShipEngineEventListener();
+        // Ultimately, we want:
+        // $spy = \Mockery::spy(self::$event_listener);
+        // OR
+        // $foo = \Mockery::mock($listener);
+        // $foo->shouldReceive('onRequestSent')
+        // ->once();
+        # $mock_request = self::$shipengine->validateAddress($good_address);
+
+        // assert
+        //\Mockery::close();
+    }
+    
+}

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -6,24 +6,36 @@ use DateInterval;
 use DateTime;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use ShipEngine\Message\Events\RequestSentEvent;
+use ShipEngine\Message\Events\ShipEngineEventListener;
 use ShipEngine\Model\Address\Address;
 use ShipEngine\ShipEngine;
 use ShipEngine\Util\Constants\Endpoints;
 
 /**
  * @covers \ShipEngine\Message\Events\RequestSentEvent
+ * @covers \ShipEngine\Message\Events\ResponseReceivedEvent
+ * @covers \ShipEngine\Message\Events\ShipEngineEvent
+ * @covers \ShipEngine\Message\Events\ShipEngineEventListener
+ * @uses \ShipEngine\Model\Address\Address
+ * @uses \ShipEngine\Model\Address\AddressValidateResult
+ * @uses \ShipEngine\Service\Address\AddressService
+ * @uses \ShipEngine\ShipEngine
+ * @uses \ShipEngine\ShipEngineClient
+ * @uses \ShipEngine\ShipEngineConfig
+ * @uses \ShipEngine\Util\Assert
+ * @uses \ShipEngine\Util\VersionInfo
  */
 final class RequestSentEventTest extends MockeryTestCase
 {
     public function testRequestSent(): void
-    {  
-        $spy = \Mockery::spy('ShipEngineEventListener');      
+    {
+        $spy = \Mockery::spy('ShipEngineEventListener');
         $config_options = $this->stubConfig($spy);
         $ship_engine = new ShipEngine($config_options);
         $good_address = $this->stubAddress();
-    
+
         $ship_engine->validateAddress($good_address);
-        
+
         $event_result = null;
         $spy->shouldHaveReceived('onRequestSent')
             ->withArgs(function ($event) use (&$event_result) {
@@ -32,10 +44,11 @@ final class RequestSentEventTest extends MockeryTestCase
             })
             ->once();
 
-        $this->assertRequestEvent($event_result, $config_options);     
+        $this->assertRequestEvent($event_result, $config_options);
     }
 
-    public function assertRequestEvent($event, $config_options) : void {
+    public function assertRequestEvent($event, $config_options) : void
+    {
         $this->assertInstanceOf(RequestSentEvent::class, $event);
         $this->assertEqualsWithDelta($event->timestamp, new DateTime(), 5);
         $this->assertEquals($event->type, RequestSentEvent::REQUEST_SENT);
@@ -48,12 +61,14 @@ final class RequestSentEventTest extends MockeryTestCase
         $this->assertEquals($event->timeout, $config_options['timeout']);
     }
 
-    private function expectedMessage($config_options) : string {
+    private function expectedMessage($config_options) : string
+    {
         $url = $config_options['base_url'];
         return "Calling the ShipEngine address/validate API at {$url}";
     }
 
-    private function stubAddress() : Address {
+    private function stubAddress() : Address
+    {
         return new Address(
             array(
                 'street' => array('11222 Washington Pl'),
@@ -65,7 +80,8 @@ final class RequestSentEventTest extends MockeryTestCase
         );
     }
 
-    private function stubConfig($event_listener) : array {
+    private function stubConfig($event_listener) : array
+    {
         return array(
             'api_key' => 'baz',
             'base_url' => Endpoints::TEST_RPC_URL,


### PR DESCRIPTION
## Background
This pull request adds a test for ensuring the `RequestSentEvent` is fired when a request is sent by the ShipEngine client. It should be similar to the `js` SDK tests, at: https://github.com/ShipEngine/shipengine-js/blob/6363c722569436a69c4ffa7fe5f1c51e17c12e8d/test/specs/events.spec.js#L9-L37.

There were a number of complications with testing the event using PHPUnit, I am open to documenting more of these in the code itself, subject to what is appropriate for the SDKs. Of note:
1. `final` classes in PHPUnit cannot be directly tested, but here this is addressed by using the Mockery library, which also allows us to create a `spy`.
2. There are a number of ways to test the arguments of a called function, here we want to test the event being passed in as an argument to the listener, see: `on` vs `with` vs `withArgs` at http://docs.mockery.io/en/latest/reference/argument_validation.html#complex-argument-validation
3. When using a closure to test arguments coming into a tested function, one is a bit limited, and cannot issue assertions within the closure. The main contributor for PHPUnit has indicated "Do not call assertions in closures then, sorry." (See: https://github.com/sebastianbergmann/phpunit/issues/4371#issuecomment-751595971). Here we use a rather ugly side effect/reference capture to get the `$event_result`, for this `spy` and this is based on similar code for Mockery mocks, which use the same approach for its `capture` method. See `vendor/mockery/mockery/library/Mockery.php` line 434. 


## Testing
1. You can run this test in isolation with `./vendor/bin/phpunit --process-isolation --filter RequestSentEventTest`
2. If one is so inclined, you can verify you get a nice failure by adding a failing assertion on line 34 of `tests/Message/Events/RequestSentEventTest.php`, like `$this->assertEquals($event_result->retry, 1);`.
3. Ensure all tests pass by running `composer phpunit`.
4. Ensure the assertions indicated in the task are all represented.