### PR TITLE
Config tests

### DIFF
--- a/.github/workflows/shipengine-php.yml
+++ b/.github/workflows/shipengine-php.yml
@@ -14,16 +14,8 @@ env:
 
 jobs:
   php_tests:
-    name: Testing shipengine-php SDK on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
-    strategy:
-      fail-fast: true
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+    name: shipengine-php
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/shipengine-php.yml
+++ b/.github/workflows/shipengine-php.yml
@@ -13,9 +13,17 @@ env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    name: shipengine-php
+  php_tests:
+    name: Testing shipengine-php SDK on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ composer lint
 
 Contributing
 ============
+Contributions, enhancements, and bug-fixes are welcome!  [Open an issue](https://github.com/ShipEngine/shipengine-php/issues)
+on GitHub and [submit a pull request](https://github.com/ShipEngine/shipengine-php/pulls).
+
 We are managing `php environment` with [Nix](https://nixos.org/download.html "Nix Website")
 and [Direnv](https://direnv.net/docs/installation.html "Direnv Install page"), and we recommend downloading
 them before contributing to this project.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $config = array(
     'apiKey' => 'baz',
     'pageSize' => 75,
     'retries' => 3,
-    'timeout' => \DateInterval('PT15000S')
+    'timeout' => \DateInterval('PT15S')
 );
 
 $shipengine = new ShipEngine($config);

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Methods
   which the address resides.
 - [normalizeAddress](./docs/normalizeAddressExample.md) - Returns a normalized, or standardized, version of the
   address. If the address cannot be normalized, an error is returned.
-- [trackPackage]() - Track a package by `packageId` or by `carrierCode` and `trackingNumber`. This method returns
+- [trackPackage](./docs/trackPackageExample.md) - Track a package by `packageId` or by `carrierCode` and `trackingNumber`. This method returns
 the all tracking events for a given shipment.
 
 Class Objects

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ A PHP library built on the [ShipEngine API](https://shipengine.com) offering low
 
 </hr>
 
+## Table of Contents
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+  * [Methods](#methods)
+  * [Class Objects](#class-objects)
+  * [Instantiate ShipEngine Class](#instantiate-shipengine-class)
+- [Testing](#testing)
+- [Linting](#linting)
+- [Contributing](#contributing)
+
 Quick Start
 ===========
 Install ShipEngine via [Composer](https://getcomposer.org/):
@@ -27,8 +37,8 @@ composer require shipengine/shipengine
 Examples
 ========
 
-`Methods`
---------
+Methods
+-------
 - [validateAddress](./docs/addressValidateExample.md) -  Indicates whether the provided address is valid. If the
   address is valid, the method returns a normalized version of the address based on the standards of the country in
   which the address resides.
@@ -37,8 +47,8 @@ Examples
 - [trackPackage]() - Track a package by `packageId` or by `carrierCode` and `trackingNumber`. This method returns
 the all tracking events for a given shipment.
 
-`Class Objects`
----------------
+Class Objects
+--------------
 - [ShipEngine]() - A configurable entry point to the ShipEngine API SDK, this class provides convenience methods
   for various ShipEngine API Services.
 
@@ -76,7 +86,7 @@ $shipengine = new ShipEngine($config);
 ```
 
 Testing
--------
+=======
 - You can now run all tests using [PHPUnit](https://phpunit.de/):
 _phpunit_
 ```bash
@@ -84,7 +94,7 @@ composer test
 ```
 
 Linting
--------
+=======
 You can utilize the `composer` script that runs **phpcs**, **phpstan**, and **php-cs-fixer**.
 ```bash
 composer lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ShipEngine PHP
 [![Coverage Status](https://coveralls.io/repos/github/ShipEngine/shipengine-php/badge.svg?branch=main&t=SkXqIE)](https://coveralls.io/github/ShipEngine/shipengine-php?branch=main)
 [![Latest Unstable Version](https://poser.pugx.org/shipengine/shipengine/v/unstable)](//packagist.org/packages/shipengine/shipengine)
 [![License](https://poser.pugx.org/shipengine/shipengine/license)](//packagist.org/packages/shipengine/shipengine)
-
+![OS Compatibility](https://shipengine.github.io/img/badges/os-badges.svg)
 > :warning: **WARNING**: This is alpha software under active development. `Caveat emptor` until a 0.1.0 release is ready.
 
 A PHP library built on the [ShipEngine API](https://shipengine.com) offering low-level access as well as convenience methods.
@@ -24,10 +24,23 @@ composer require shipengine/shipengine
 
 > The following example assumes that you have already set the `SHIPENGIEN_API_KEY` using `putenv()`.
 
-`Examples`
-----------
-- [Validate an Address](./docs/addressValidateExample.md)
-- [Normalize an Address](./docs/normalizeAddressExample.md)
+Examples
+========
+
+`Methods`
+--------
+- [validateAddress](./docs/addressValidateExample.md) -  Indicates whether the provided address is valid. If the
+  address is valid, the method returns a normalized version of the address based on the standards of the country in
+  which the address resides.
+- [normalizeAddress](./docs/normalizeAddressExample.md) - Returns a normalized, or standardized, version of the
+  address. If the address cannot be normalized, an error is returned.
+- [trackPackage]() - Track a package by `packageId` or by `carrierCode` and `trackingNumber`. This method returns
+the all tracking events for a given shipment.
+
+`Class Objects`
+---------------
+- [ShipEngine]() - A configurable entry point to the ShipEngine API SDK, this class provides convenience methods
+  for various ShipEngine API Services.
 
 Instantiate ShipEngine Class
 ------------------------------
@@ -50,8 +63,10 @@ require __DIR__ . '/vendor/autoload.php';
 
 use ShipEngine\ShipEngine;
 
+$apiKey = getenv('SHIPENGINE_API_KEY');
+
 $config = array(
-    'apiKey' => 'baz',
+    'apiKey' => $apiKey,
     'pageSize' => 75,
     'retries' => 3,
     'timeout' => \DateInterval('PT15S')
@@ -65,28 +80,36 @@ Testing
 - You can now run all tests using [PHPUnit](https://phpunit.de/):
 _phpunit_
 ```bash
-composer phpunit
+composer test
 ```
-- You can also run `phpcs`:
 
-_phpcs_
+Linting
+-------
+You can utilize the `composer` script that runs **phpcs**, **phpstan**, and **php-cs-fixer**.
 ```bash
-composer phpcs
+composer lint
 ```
 
-Lint
-----
-_phpstan_ using our `composer script`:
-```bash
-composer phpstan
-```
+Contributing
+============
+We are managing `php environment` with [Nix](https://nixos.org/download.html "Nix Website")
+and [Direnv](https://direnv.net/docs/installation.html "Direnv Install page"), and we recommend downloading
+them before contributing to this project.
 
-Generate Documentation
-----------------------
-```bash
-composer gen:docs
-```
+- The quickest way to install Nix is to open a terminal and run the following command, make sure to follow the
+  instructions output by the installation script:
+  ```bash
+  curl -L https://nixos.org/nix/install | sh
+  ```
 
-Local Development
-=================
-We are managing `php environment` with [Nix](https://nixos.org/download.html "Nix Website") and [Direnv](https://direnv.net/docs/installation.html "Direnv Install page"), and we recommend downloading them before contributing to this project.
+- Next, install `Direnv` using one of th methods outlined on their install page here:
+  [Direnv Installation](https://direnv.net/docs/installation.html "Direnv Install page")
+
+- Lastly, you will need open your terminal and while this repository the current working directory and run `direnv allow`,
+  this will allow `direnv` to auto-load every time you navigate to the repo. This will automatically load the `Nix`
+  environment which is running the proper version of `PHP and Xdebug (PHP 7.4)` this repository supports/requires.
+  ```bash
+  direnv allow
+  ```
+  - You will need to `cd` out of the project directory after you first install `direnv` and run `direnv allow` from within
+    the project directory, and then `cd` back into the project directory for `direnv` to auto-load the `Nix` environment properly.

--- a/README.md
+++ b/README.md
@@ -126,3 +126,10 @@ them before contributing to this project.
   ```
   - You will need to `cd` out of the project directory after you first install `direnv` and run `direnv allow` from within
     the project directory, and then `cd` back into the project directory for `direnv` to auto-load the `Nix` environment properly.
+
+This project also makes use of `pre-commit hooks` to help run lint and tests at time of commit, to leverage this you will
+need to install [pre-commit](https://pre-commit.com/#installation) and run the following command while in this repo:
+
+```bash
+pre-commit install
+```

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     "sort-packages": true
   },
   "scripts": {
-    "phpunit": "./vendor/bin/phpunit",
+    "lint": "composer phpcs-fixer && composer phpcs && composer phpstan",
+    "test": "./vendor/bin/phpunit",
     "phpstan": "./vendor/bin/phpstan analyse src --level 5",
     "phpcs": "./vendor/bin/phpcs --standard=PSR2 src",
     "phpcs-fixer": "./vendor/bin/php-cs-fixer fix -vv --config=.php-cs-fixer.dist.php",

--- a/docs/addressValidateExample.md
+++ b/docs/addressValidateExample.md
@@ -24,8 +24,8 @@ There are two ways to validate an address using this SDK.
   requires a `countryCode` which should be the 2 character capitalized abbreviation for a given countryCode.
 
 - **Behavior**: The `validateAddress` method will always return
-  an [AddressValidateResult](../src/Model/Address/AddressValidateResult.php), even in the even that the address passed
-  in was not *valid*.
+  an [AddressValidateResult](../src/Model/Address/AddressValidateResult.php) object, even in the even that the
+  address passed in was not *valid*.
 
 - **Method level configuration** - You can optionally pass in an array that contains `configuration` values to be used
   for the current method call. The options are `apiKey`, `baseUrl`, `pageSize`,
@@ -65,7 +65,7 @@ require __DIR__ . '/vendor/autoload.php';
 use ShipEngine\Model\Address\Address;
 use ShipEngine\ShipEngine;
 
-$apiKey = getenv('SHIPENGINE_apiKey');
+$apiKey = getenv('SHIPENGINE_API_KEY');
 
 $shipengine = new ShipEngine($apiKey);
 
@@ -135,7 +135,7 @@ the `jsonSerialize()` method. View the example below:
 
 $validated_address = $shipengine->validateAddress($address, ['retries' => 2]);
 
-print_r(json_encode($validated_address));  // Return the AddressValidateResult Type as a JSON string.
+print_r(json_encode($validated_address, JSON_PRETTY_PRINT));  // Return the AddressValidateResult Type as a JSON string.
 ```
 
 **Successful Address Validation Output:**: This is the `AddressValidateResult` Type serialized as JSON.

--- a/docs/trackPackageExample.md
+++ b/docs/trackPackageExample.md
@@ -1,0 +1,485 @@
+Package Tracking Documentation
+==============================
+With ShipEngine, you can subscribe to real-time tracking events for any package – regardless of whether you
+created the label via ShipEngine.
+
+---
+
+There are two ways to track a package using this SDK.
+
+- Track by Carrier Code and Tracking Number - `trackPackage(TrackingQuery $trackingData, $config);`
+- Track by PackageId - `trackPackage('abcFedExDelivered', $config)`
+
+`trackPackage(string|TrackingQuery $trackingData, $config)` - Track a given package or shipment.
+=========================================================================
+- The `trackPackage` method can be used in two ways, you can either track by `PackageId` by passing it as a string
+to this method. Alternatively, you can track by `carrierCode` and `trackingNumber` by passing in an instance
+  of [TrackingQuery](../src/Model/Package/TrackingQuery.php) which has `carrierCode` and `trackingNumber` properties
+  on it that are used within this method.
+
+- **Behavior**: The `trackPackage` method will always return
+  an [TrackPackageResult](../src/Model/Package/TrackPackageResult.php) object, and in the event of an exception an
+  instance or extension of [ShipEngineException](../src/Message/ShipEngineException.php) will be returned.
+
+- **Method level configuration** - You can optionally pass in an array that contains `configuration` values to be used
+  for the current method call. The options are `apiKey`, `baseUrl`, `pageSize`,
+  `retries` **(MUST be of type `DateInterval` e.g. `new DateInterval('PT5S')` would be 5 seconds)**,
+  `timeout`, and `eventListener`.
+
+> Learn more about `DateInterval()` in the php manual:
+> [DateInterval PHP Manual](https://www.php.net/manual/en/class.dateinterval.php "DateInterval Documentation")
+
+Examples:
+=========
+
+**Successful TrackPackage by TrackingNumber and Carrier Code:** - This example illustrates the following:
+- Instantiate the ShipEngine class.
+- Create a `TrackingQuery` object and pass it into the `trackPackage` method.
+- Use the `trackPackage` method to track a given shipment using the tracking data in the previous step.
+- Print out the result to view tracking data response from ShipEngine API.
+
+```php
+<?php declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use ShipEngine\Model\Package\TrackingQuery;
+use ShipEngine\ShipEngine;
+
+$apiKey = getenv('SHIPENGINE_apiKey');
+
+$shipengine = new ShipEngine($apiKey);
+
+$trackingData = new TrackingQuery('fedex', 'abcFedExDelivered');
+
+$trackingResult = $shipengine->trackPackage($trackingData, ['retries' => 2]);
+
+print_r($trackingResult);
+```
+
+**Successful TrackPackage by Tracking Number and Carrier Code Output:**: As a raw `TrackPackageResult` object.
+```php
+ShipEngine\Model\Package\TrackPackageResult Object
+(
+    [shipment] => ShipEngine\Model\Package\Shipment Object
+        (
+            [shipmentId] =>
+            [accountId] =>
+            [carrierAccount] =>
+            [carrier] => ShipEngine\Model\Carriers\Carrier Object
+                (
+                    [name] => FedEx
+                    [code] => fedex
+                )
+
+            [estimatedDeliveryDate] => ShipEngine\Util\IsoString Object
+                (
+                    [value:ShipEngine\Util\IsoString:private] => 2021-05-18T21:00:00.000Z
+                )
+
+            [actualDeliveryDate] => ShipEngine\Util\IsoString Object
+                (
+                    [value:ShipEngine\Util\IsoString:private] => 2021-05-15T19:00:00.000Z
+                )
+
+        )
+
+    [package] => ShipEngine\Model\Package\Package Object
+        (
+            [packageId] =>
+            [weight] =>
+            [dimensions] =>
+            [trackingNumber] => abcFedExDelivered
+            [trackingUrl] => https://www.fedex.com/track/abcFedExDelivered
+        )
+
+    [events] => Array
+        (
+            [0] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-13T19:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-14T01:00:00
+                        )
+
+                    [status] => accepted
+                    [description] => Dropped-off at shipping center
+                    [carrierStatusCode] => ACPT-2
+                    [carrierDetailCode] => PU7W
+                    [signer] =>
+                    [location] =>
+                )
+
+            [1] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-14T01:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-14T07:00:00
+                        )
+
+                    [status] => in_transit
+                    [description] => En-route to distribution center hub
+                    [carrierStatusCode] => ER00P
+                    [carrierDetailCode] =>
+                    [signer] =>
+                    [location] =>
+                )
+
+            [2] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-14T20:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-15T02:00:00
+                        )
+
+                    [status] => unknown
+                    [description] => Mechanically sorted
+                    [carrierStatusCode] => MMSa
+                    [carrierDetailCode] => 00004134918400045
+                    [signer] =>
+                    [location] =>
+                )
+
+            [3] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-15T10:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-15T16:00:00
+                        )
+
+                    [status] => in_transit
+                    [description] => On vehicle for delivery
+                    [carrierStatusCode] => OFD-22
+                    [carrierDetailCode] => 91R-159E
+                    [signer] =>
+                    [location] =>
+                )
+
+            [4] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-15T19:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-16T01:00:00
+                        )
+
+                    [status] => delivered
+                    [description] => Delivered
+                    [carrierStatusCode] => DV99-0004
+                    [carrierDetailCode] =>
+                    [signer] => John P. Doe
+                    [location] => ShipEngine\Model\Package\Location Object
+                        (
+                            [cityLocality] =>
+                            [stateProvince] =>
+                            [postalCode] => 12345
+                            [countryCode] =>
+                            [latitude] => 39.2271052
+                            [longitude] => -111.0306202
+                        )
+
+                )
+
+        )
+
+)
+```
+
+Continuing with the example at the top, you can also serialize the `TrackPackageResult` Type to a JSON string by using
+the `jsonSerialize()` method. View the example below:
+
+```php
+... Omitted Code
+
+$trackingRes = $shipengine->trackPackage($trackingData, ['retries' => 2]);
+
+print_r(json_encode($trackingRes, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));  // Return the TrackPackageResult Type as a JSON string.
+```
+
+**Successful TrackPackage by Tracking Number and Carrier Code Output:**: This is the `TrackPackageResult` Type serialized as JSON.
+```json5
+{
+    "shipment": {
+        "shipmentId": null,
+        "carrierAccountID": null,
+        "carrierAccount": null,
+        "carrier": {
+            "name": "FedEx",
+            "code": "fedex"
+        },
+        "estimatedDeliveryDate": "2021-05-18T21:00:00.000Z",
+        "actualDeliveryDate": "2021-05-15T19:00:00.000Z"
+    },
+    "package": {
+        "packageId": null,
+        "weight": null,
+        "dimensions": null,
+        "trackingNumber": "abcFedExDelivered",
+        "trackingUrl": "https://www.fedex.com/track/abcFedExDelivered"
+    },
+    "events": [
+        {
+            "dateTime": "2021-05-13T19:00:00.000Z",
+            "carrierDateTime": "2021-05-14T01:00:00",
+            "status": "accepted",
+            "description": "Dropped-off at shipping center",
+            "carrierStatusCode": "ACPT-2",
+            "carrierDetailCode": "PU7W",
+            "signer": null,
+            "location": null
+        },
+        {
+            "dateTime": "2021-05-14T01:00:00.000Z",
+            "carrierDateTime": "2021-05-14T07:00:00",
+            "status": "in_transit",
+            "description": "En-route to distribution center hub",
+            "carrierStatusCode": "ER00P",
+            "carrierDetailCode": null,
+            "signer": null,
+            "location": null
+        },
+        {
+            "dateTime": "2021-05-14T20:00:00.000Z",
+            "carrierDateTime": "2021-05-15T02:00:00",
+            "status": "unknown",
+            "description": "Mechanically sorted",
+            "carrierStatusCode": "MMSa",
+            "carrierDetailCode": "00004134918400045",
+            "signer": null,
+            "location": null
+        },
+        {
+            "dateTime": "2021-05-15T10:00:00.000Z",
+            "carrierDateTime": "2021-05-15T16:00:00",
+            "status": "in_transit",
+            "description": "On vehicle for delivery",
+            "carrierStatusCode": "OFD-22",
+            "carrierDetailCode": "91R-159E",
+            "signer": null,
+            "location": null
+        },
+        {
+            "dateTime": "2021-05-15T19:00:00.000Z",
+            "carrierDateTime": "2021-05-16T01:00:00",
+            "status": "delivered",
+            "description": "Delivered",
+            "carrierStatusCode": "DV99-0004",
+            "carrierDetailCode": null,
+            "signer": "John P. Doe",
+            "location": {
+                "cityLocality": null,
+                "stateProvince": null,
+                "postalCode": "12345",
+                "countryCode": null,
+                "latitude": 39.2271052,
+                "longitude": -111.0306202
+            }
+        }
+    ]
+}
+```
+OR you can track by **packageId**
+
+**Successful TrackPackage by PackageId** - This example illustrates how to track a given shipment by `packageId`.
+- Instantiate the ShipEngine class.
+- Pass `packageId` as a string into the `trackPackage` method.
+- Use the `trackPackage` method to track a given shipment using the tracking data in the previous step.
+- Print out the result to view tracking data response from ShipEngine API.
+
+```php
+<?php declare(strict_types=1);
+
+require __DIR__ . '/vendor/autoload.php';
+
+use ShipEngine\ShipEngine;
+
+$apiKey = getenv('SHIPENGINE_apiKey');
+
+$shipengine = new ShipEngine($apiKey);
+
+$trackingData = 'pkg_1FedExAccepted';
+
+$trackingResult = $shipengine->trackPackage($trackingData, ['retries' => 2]);
+
+print_r($trackingResult);
+```
+**Successful TrackPackage by PackageId Output:**: As a raw `TrackPackageResult` object.
+```php
+ShipEngine\Model\Package\TrackPackageResult Object
+(
+    [shipment] => ShipEngine\Model\Package\Shipment Object
+        (
+            [shipmentId] => shp_yuh3GkfUjTZSEAQ
+            [accountId] => car_kfUjTZSEAQ8gHeT
+            [carrierAccount] => ShipEngine\Model\Carriers\CarrierAccount Object
+                (
+                    [carrier] => ShipEngine\Model\Carriers\Carrier Object
+                        (
+                            [name] => FedEx
+                            [code] => fedex
+                        )
+
+                    [accountId] => car_kfUjTZSEAQ8gHeT
+                    [accountNumber] => 41E-4928-29314AAX
+                    [name] => FedEx Account #1
+                )
+
+            [carrier] => ShipEngine\Model\Carriers\Carrier Object
+                (
+                    [name] => FedEx
+                    [code] => fedex
+                )
+
+            [estimatedDeliveryDate] => ShipEngine\Util\IsoString Object
+                (
+                    [value:ShipEngine\Util\IsoString:private] => 2021-05-18T21:00:00.000Z
+                )
+
+            [actualDeliveryDate] => ShipEngine\Util\IsoString Object
+                (
+                    [value:ShipEngine\Util\IsoString:private] => 2021-05-16T13:00:00.000Z
+                )
+
+        )
+
+    [package] => ShipEngine\Model\Package\Package Object
+        (
+            [packageId] => pkg_1FedExAccepted
+            [weight] => Array
+                (
+                    [value] => 76
+                    [unit] => kilogram
+                )
+
+            [dimensions] => Array
+                (
+                    [length] => 36
+                    [width] => 36
+                    [height] => 23
+                    [unit] => inch
+                )
+
+            [trackingNumber] => 5fSkgyuh3GkfUjTZSEAQ8gHeTU29tZ
+            [trackingUrl] => https://www.fedex.com/track/5fSkgyuh3GkfUjTZSEAQ8gHeTU29tZ
+        )
+
+    [events] => Array
+        (
+            [0] => ShipEngine\Model\Package\TrackingEvent Object
+                (
+                    [dateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-16T13:00:00.000Z
+                        )
+
+                    [carrierDateTime] => ShipEngine\Util\IsoString Object
+                        (
+                            [value:ShipEngine\Util\IsoString:private] => 2021-05-16T19:00:00
+                        )
+
+                    [status] => accepted
+                    [description] => Dropped-off at shipping center
+                    [carrierStatusCode] => ACPT-2
+                    [carrierDetailCode] =>
+                    [signer] =>
+                    [location] =>
+                )
+
+        )
+
+)
+```
+
+Continuing with the example at the top, you can also serialize the `TrackPackageResult` Type to a JSON string by using
+the `jsonSerialize()` method. View the example below:
+
+```php
+... Omitted Code
+
+$trackingRes = $shipengine->trackPackage($trackingData, ['retries' => 2]);
+
+print_r(json_encode($trackingRes, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));  // Return the TrackPackageResult Type as a JSON string.
+```
+
+**Successful TrackPackage by PackageId Output:**: This is the `TrackPackageResult` Type serialized as JSON.
+```json5
+{
+    "shipment": {
+        "shipmentId": "shp_yuh3GkfUjTZSEAQ",
+        "carrierAccountID": "car_kfUjTZSEAQ8gHeT",
+        "carrierAccount": {
+            "carrier": {
+                "name": "FedEx",
+                "code": "fedex"
+            },
+            "accountId": "car_kfUjTZSEAQ8gHeT",
+            "accountNumber": "41E-4928-29314AAX",
+            "name": "FedEx Account #1"
+        },
+        "carrier": {
+            "name": "FedEx",
+            "code": "fedex"
+        },
+        "estimatedDeliveryDate": "2021-05-18T21:00:00.000Z",
+        "actualDeliveryDate": "2021-05-16T13:00:00.000Z"
+    },
+    "package": {
+        "packageId": "pkg_1FedExAccepted",
+        "weight": {
+            "value": 76,
+            "unit": "kilogram"
+        },
+        "dimensions": {
+            "length": 36,
+            "width": 36,
+            "height": 23,
+            "unit": "inch"
+        },
+        "trackingNumber": "5fSkgyuh3GkfUjTZSEAQ8gHeTU29tZ",
+        "trackingUrl": "https://www.fedex.com/track/5fSkgyuh3GkfUjTZSEAQ8gHeTU29tZ"
+    },
+    "events": [
+        {
+            "dateTime": "2021-05-16T13:00:00.000Z",
+            "carrierDateTime": "2021-05-16T19:00:00",
+            "status": "accepted",
+            "description": "Dropped-off at shipping center",
+            "carrierStatusCode": "ACPT-2",
+            "carrierDetailCode": null,
+            "signer": null,
+            "location": null
+        }
+    ]
+}
+```
+
+Exceptions
+==========
+
+- This method will only throw an exception that is an instance/extension of
+  ([ShipEngineException](../src/Message/ShipEngineException.php)) if there is a problem if a problem occurs, such as a
+  network error or an error response from the API.

--- a/src/Message/Events/EventMessage.php
+++ b/src/Message/Events/EventMessage.php
@@ -4,12 +4,23 @@ namespace ShipEngine\Message\Events;
 
 use ShipEngine\Message\ShipEngineException;
 
+/**
+ * Class EventMessage - This class houses helper methods related to event messages.
+ *
+ * @package ShipEngine\Message\Events
+ */
 final class EventMessage
 {
+    /**
+     * A method to dynamically create an event message based on the $messageType being passed in.
+     *
+     * @param string $method RPC method name.
+     * @param string $baseUri The base url of the client.
+     * @param string $messageType The type of event message to be returned.
+     * @return string
+     */
     public static function newEventMessage(string $method, string $baseUri, string $messageType): string
     {
-//        $message = null;
-
         switch ($messageType) {
             case 'base_message':
                 return "Calling the ShipEngine $method API at $baseUri";
@@ -18,12 +29,5 @@ final class EventMessage
             default:
                 throw new ShipEngineException("Message type [$messageType] is not a valid type of message");
         }
-
-//        if ($messageType === 'base_message') {
-//            $message = "Calling the ShipEngine $method API at $baseUri";
-//        } elseif ($messageType === 'retry_message') {
-//            $message = "Retrying the ShipEngine $method API at $baseUri";
-//        }
-//        return $message;
     }
 }

--- a/src/Message/Events/EventMessage.php
+++ b/src/Message/Events/EventMessage.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace ShipEngine\Message\Events;
+
+use ShipEngine\Message\ShipEngineException;
+
+final class EventMessage
+{
+    public static function newEventMessage(string $method, string $baseUri, string $messageType): string
+    {
+//        $message = null;
+
+        switch ($messageType) {
+            case 'base_message':
+                return "Calling the ShipEngine $method API at $baseUri";
+            case 'retry_message':
+                return "Retrying the ShipEngine $method API at $baseUri";
+            default:
+                throw new ShipEngineException("Message type [$messageType] is not a valid type of message");
+        }
+
+//        if ($messageType === 'base_message') {
+//            $message = "Calling the ShipEngine $method API at $baseUri";
+//        } elseif ($messageType === 'retry_message') {
+//            $message = "Retrying the ShipEngine $method API at $baseUri";
+//        }
+//        return $message;
+    }
+}

--- a/src/Message/Events/EventOptions.php
+++ b/src/Message/Events/EventOptions.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace ShipEngine\Message\Events;
+
+use DateInterval;
+
+/**
+ * Class EventOptions
+ *
+ * @package ShipEngine\Message\Events
+ */
+final class EventOptions
+{
+    /**
+     * Event message to be emitted.
+     *
+     * @var string|null
+     */
+    public ?string $message;
+
+    /**
+     * The requestId that corresponds to the request that was sent when this event is emitted.
+     *
+     * @var string|null
+     */
+    public ?string $id;
+
+    /**
+     * @var string|null
+     */
+    public ?string $baseUri;
+
+    /**
+     * The request or response body content as an associative array.
+     *
+     * @var array|null
+     */
+    public ?array $body;
+
+    /**
+     * An array of request headers that was sent on the request that triggered this event.
+     *
+     * @var array|null
+     */
+    public ?array $requestHeaders;
+
+    /**
+     * @var array|null
+     */
+    public ?array $responseHeaders;
+
+    /**
+     * The response status code.
+     *
+     * @var int|null
+     */
+    public ?int $statusCode;
+
+    /**
+     * The current retry - this is used in the retry logic that the ShipEngineClient executes.
+     *
+     * @var int|null
+     */
+    public ?int $retry;
+
+    /**
+     * @var DateInterval|null
+     */
+    public ?DateInterval $timeout;
+
+    /**
+     * This is the elapsed time between the `RequestSentEvent` and the
+     * `ResponseReceivedEvent`.
+     *
+     * @var DateInterval|null
+     * @link https://www.php.net/manual/en/class.dateinterval.php     */
+    public ?DateInterval $elapsed;
+
+    /**
+     * EventOptions constructor - To be used as the main argument in the **ShipEngineEvent::emitEvent()** method.
+     *
+     * @param array $eventData
+     */
+    public function __construct(array $eventData)
+    {
+        $this->message = $eventData['message'];
+        $this->id = $eventData['id'];
+        $this->baseUri = $eventData['baseUri'];
+        $this->requestHeaders = $eventData['requestHeaders'];
+        $this->responseHeaders = $eventData['responseHeaders'];
+        $this->statusCode = $eventData['statusCode'];
+        $this->body = $eventData['body'];
+        $this->retry = $eventData['retry'];
+        $this->timeout = $eventData['timeout'];
+        $this->elapsed = $eventData['elapsed'];
+    }
+}

--- a/src/Message/Events/EventOptions.php
+++ b/src/Message/Events/EventOptions.php
@@ -83,15 +83,15 @@ final class EventOptions
      */
     public function __construct(array $eventData)
     {
-        $this->message = $eventData['message'];
-        $this->id = $eventData['id'];
-        $this->baseUri = $eventData['baseUri'];
-        $this->requestHeaders = $eventData['requestHeaders'];
-        $this->responseHeaders = $eventData['responseHeaders'];
-        $this->statusCode = $eventData['statusCode'];
-        $this->body = $eventData['body'];
-        $this->retry = $eventData['retry'];
-        $this->timeout = $eventData['timeout'];
-        $this->elapsed = $eventData['elapsed'];
+        $this->message = isset($eventData['message']) ? $eventData['message'] : null;
+        $this->id = isset($eventData['id']) ? $eventData['id'] : null;
+        $this->baseUri = isset($eventData['baseUri']) ? $eventData['baseUri'] : null;
+        $this->requestHeaders = isset($eventData['requestHeaders']) ? $eventData['requestHeaders'] : null;
+        $this->responseHeaders = isset($eventData['responseHeaders']) ? $eventData['responseHeaders'] : null;
+        $this->statusCode = isset($eventData['statusCode']) ? $eventData['statusCode'] : null;
+        $this->body = isset($eventData['body']) ? $eventData['body'] : null;
+        $this->retry = isset($eventData['retry']) ? $eventData['retry'] : null;
+        $this->timeout = isset($eventData['timeout']) ? $eventData['timeout'] : null;
+        $this->elapsed = isset($eventData['elapsed']) ? $eventData['elapsed'] : null;
     }
 }

--- a/src/Message/Events/RequestSentEvent.php
+++ b/src/Message/Events/RequestSentEvent.php
@@ -5,7 +5,9 @@ namespace ShipEngine\Message\Events;
 use DateInterval;
 
 /**
- * Class RequestSentEvent
+ * Class RequestSentEvent - This event gets emitted everytime the **ShipEngineClient** sends a request to
+ * ShipEngine API.
+ *
  * @package ShipEngine\Message\Events
  */
 final class RequestSentEvent extends ShipEngineEvent implements \JsonSerializable

--- a/src/Message/Events/ResponseReceivedEvent.php
+++ b/src/Message/Events/ResponseReceivedEvent.php
@@ -5,7 +5,9 @@ namespace ShipEngine\Message\Events;
 use DateInterval;
 
 /**
- * Class ResponseReceivedEvent
+ * Class ResponseReceivedEvent - This event gets emitted everytime the **ShipEngineClient** sends received a
+ * response to ShipEngine API.
+ *
  * @package ShipEngine\Message\Events
  */
 final class ResponseReceivedEvent extends ShipEngineEvent implements \JsonSerializable

--- a/src/Message/Events/ShipEngineEvent.php
+++ b/src/Message/Events/ShipEngineEvent.php
@@ -48,6 +48,13 @@ class ShipEngineEvent extends Event
         $this->message = $message;
     }
 
+    /**
+     * A helper method to dynamically create any of the events that are dispatched by this SDK.
+     *
+     * @param string $eventType
+     * @param ShipEngineConfig $config
+     * @return ShipEngineEvent
+     */
     public static function emitEvent(string $eventType, $eventData, ShipEngineConfig $config): ShipEngineEvent
     {
         $dispatcher = new EventDispatcher();
@@ -93,48 +100,5 @@ class ShipEngineEvent extends Event
             default:
                 throw new ShipEngineException("Event type [$eventType] is not a valid type of event.");
         }
-
-//        if ($eventType === RequestSentEvent::REQUEST_SENT) {
-//            $requestSentEvent = new RequestSentEvent(
-//                $eventData->message,
-//                $eventData->id,
-//                $eventData->baseUri,
-//                $eventData->requestHeaders,
-//                $eventData->body,
-//                $eventData->retry,
-//                $eventData->timeout,
-//            );
-//
-//            $emittedEvent[] = $requestSentEvent;
-//
-//            $dispatcher->addListener(
-//                $requestSentEvent::REQUEST_SENT,
-//                [$shipengineEventListener, 'onRequestSent']
-//            );
-//
-//            $dispatcher->dispatch($requestSentEvent, $requestSentEvent::REQUEST_SENT);
-//        }
-//
-//        if ($eventType === ResponseReceivedEvent::RESPONSE_RECEIVED) {
-//            $responseReceivedEvent = new ResponseReceivedEvent(
-//                $eventData->message,
-//                $eventData->id,
-//                $eventData->baseUri,
-//                $eventData->statusCode,
-//                $eventData->headers,
-//                $eventData->body,
-//                $eventData->retry,
-//                $eventData->elapsed
-//            );
-//
-//            $emittedEvent[] = $responseReceivedEvent;
-//
-//            $dispatcher->addListener(
-//                $responseReceivedEvent::RESPONSE_RECEIVED,
-//                [$shipengineEventListener, 'onResponseReceived']
-//            );
-//            $dispatcher->dispatch($responseReceivedEvent, $responseReceivedEvent::RESPONSE_RECEIVED);
-//            return $responseReceivedEvent;
-//        }
     }
 }

--- a/src/Message/Events/ShipEngineEvent.php
+++ b/src/Message/Events/ShipEngineEvent.php
@@ -3,6 +3,9 @@
 namespace ShipEngine\Message\Events;
 
 use DateTime;
+use ShipEngine\Message\ShipEngineException;
+use ShipEngine\ShipEngineConfig;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -43,5 +46,95 @@ class ShipEngineEvent extends Event
         $this->timestamp = new DateTime();
         $this->type = $type;
         $this->message = $message;
+    }
+
+    public static function emitEvent(string $eventType, $eventData, ShipEngineConfig $config): ShipEngineEvent
+    {
+        $dispatcher = new EventDispatcher();
+        $shipengineEventListener = $config->eventListener;
+
+        switch ($eventType) {
+            case RequestSentEvent::REQUEST_SENT:
+                $requestSentEvent = new RequestSentEvent(
+                    $eventData->message,
+                    $eventData->id,
+                    $eventData->baseUri,
+                    $eventData->requestHeaders,
+                    $eventData->body,
+                    $eventData->retry,
+                    $eventData->timeout,
+                );
+
+                $dispatcher->addListener(
+                    $requestSentEvent::REQUEST_SENT,
+                    [$shipengineEventListener, 'onRequestSent']
+                );
+
+                $dispatcher->dispatch($requestSentEvent, $requestSentEvent::REQUEST_SENT);
+                return $requestSentEvent;
+            case ResponseReceivedEvent::RESPONSE_RECEIVED:
+                $responseReceivedEvent = new ResponseReceivedEvent(
+                    $eventData->message,
+                    $eventData->id,
+                    $eventData->baseUri,
+                    $eventData->statusCode,
+                    $eventData->responseHeaders,
+                    $eventData->body,
+                    $eventData->retry,
+                    $eventData->elapsed
+                );
+
+                $dispatcher->addListener(
+                    $responseReceivedEvent::RESPONSE_RECEIVED,
+                    [$shipengineEventListener, 'onResponseReceived']
+                );
+                $dispatcher->dispatch($responseReceivedEvent, $responseReceivedEvent::RESPONSE_RECEIVED);
+                return $responseReceivedEvent;
+            default:
+                throw new ShipEngineException("Event type [$eventType] is not a valid type of event.");
+        }
+
+//        if ($eventType === RequestSentEvent::REQUEST_SENT) {
+//            $requestSentEvent = new RequestSentEvent(
+//                $eventData->message,
+//                $eventData->id,
+//                $eventData->baseUri,
+//                $eventData->requestHeaders,
+//                $eventData->body,
+//                $eventData->retry,
+//                $eventData->timeout,
+//            );
+//
+//            $emittedEvent[] = $requestSentEvent;
+//
+//            $dispatcher->addListener(
+//                $requestSentEvent::REQUEST_SENT,
+//                [$shipengineEventListener, 'onRequestSent']
+//            );
+//
+//            $dispatcher->dispatch($requestSentEvent, $requestSentEvent::REQUEST_SENT);
+//        }
+//
+//        if ($eventType === ResponseReceivedEvent::RESPONSE_RECEIVED) {
+//            $responseReceivedEvent = new ResponseReceivedEvent(
+//                $eventData->message,
+//                $eventData->id,
+//                $eventData->baseUri,
+//                $eventData->statusCode,
+//                $eventData->headers,
+//                $eventData->body,
+//                $eventData->retry,
+//                $eventData->elapsed
+//            );
+//
+//            $emittedEvent[] = $responseReceivedEvent;
+//
+//            $dispatcher->addListener(
+//                $responseReceivedEvent::RESPONSE_RECEIVED,
+//                [$shipengineEventListener, 'onResponseReceived']
+//            );
+//            $dispatcher->dispatch($responseReceivedEvent, $responseReceivedEvent::RESPONSE_RECEIVED);
+//            return $responseReceivedEvent;
+//        }
     }
 }

--- a/src/Message/Events/ShipEngineEventListener.php
+++ b/src/Message/Events/ShipEngineEventListener.php
@@ -2,13 +2,31 @@
 
 namespace ShipEngine\Message\Events;
 
+/**
+ * Class ShipEngineEventListener - A default **PSR-14** event listener to consume the events
+ * emitted by this SDK.
+ *
+ * @package ShipEngine\Message\Events
+ */
 final class ShipEngineEventListener
 {
+    /**
+     * Callback to handle/consume the **RequestSentEvent** whenever it is emitted by the ShipEngine SDK.
+     *
+     * @param RequestSentEvent $event
+     * @return RequestSentEvent
+     */
     public function onRequestSent(RequestSentEvent $event)
     {
         return $event;
     }
 
+    /**
+     * Callback to handle/consume the **ResponseReceivedEvent** whenever it is emitted by the ShipEngine SDK.
+     *
+     * @param ResponseReceivedEvent $event
+     * @return ResponseReceivedEvent
+     */
     public function onResponseReceived(ResponseReceivedEvent $event)
     {
         return $event;

--- a/src/Message/RateLimitExceededException.php
+++ b/src/Message/RateLimitExceededException.php
@@ -14,7 +14,7 @@ use ShipEngine\Util\Constants\ErrorType;
 final class RateLimitExceededException extends ShipEngineException
 {
     /**
-     * The amount of time (in milliseconds) to wait before retrying the request.
+     * The amount of time (in SECONDS) to wait before retrying the request.
      *
      * @var \DateInterval
      */

--- a/src/Message/TimeoutException.php
+++ b/src/Message/TimeoutException.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace ShipEngine\Message;
+
+use ShipEngine\Util\Constants\ErrorCode;
+use ShipEngine\Util\Constants\ErrorType;
+
+final class TimeoutException extends ShipEngineException
+{
+    /**
+     * RateLimitExceededException constructor - Instantiates a server-side error.
+     *
+     * @param int $retryAfter The amount of time (in SECONDS) to wait before retrying the request.
+     * @param string|null $source
+     * @param string|null $requestId
+     */
+    public function __construct(
+        int $retryAfter,
+        string $source = null,
+        ?string $requestId = null
+    ) {
+        parent::__construct(
+            "The request took longer than the $retryAfter seconds allowed.",
+            $requestId,
+            $source,
+            ErrorType::SYSTEM,
+            ErrorCode::TIMEOUT,
+            'https://www.shipengine.com/docs/rate-limits'
+        );
+    }
+}

--- a/src/Message/TimeoutException.php
+++ b/src/Message/TimeoutException.php
@@ -5,6 +5,11 @@ namespace ShipEngine\Message;
 use ShipEngine\Util\Constants\ErrorCode;
 use ShipEngine\Util\Constants\ErrorType;
 
+/**
+ * Class TimeoutException - The exception used by this SDK when the configured/default client timeout is reached.
+ *
+ * @package ShipEngine\Message
+ */
 final class TimeoutException extends ShipEngineException
 {
     /**

--- a/src/Model/Carriers/CarrierAccount.php
+++ b/src/Model/Carriers/CarrierAccount.php
@@ -59,7 +59,7 @@ final class CarrierAccount implements \JsonSerializable
      *
      * @param array $accountInformation
      */
-    private function setCarrierAccount(array $accountInformation)
+    private function setCarrierAccount(array $accountInformation): void
     {
         if (array_key_exists('carrierCode', $accountInformation)) {
             $carrierCode = $accountInformation['carrierCode'];

--- a/src/Model/Package/Shipment.php
+++ b/src/Model/Package/Shipment.php
@@ -11,6 +11,7 @@ use ShipEngine\Util\IsoString;
 
 /**
  * Class Shipment
+ *
  * @package ShipEngine\Model\Package
  */
 final class Shipment implements \JsonSerializable

--- a/src/Model/Package/TrackPackageResult.php
+++ b/src/Model/Package/TrackPackageResult.php
@@ -2,10 +2,12 @@
 
 namespace ShipEngine\Model\Package;
 
+use Psr\Http\Client\ClientExceptionInterface;
 use ShipEngine\ShipEngineConfig;
 
 /**
  * Class TrackPackageResult
+ *
  * @package ShipEngine\Model\Package
  */
 final class TrackPackageResult implements \JsonSerializable
@@ -78,6 +80,8 @@ final class TrackPackageResult implements \JsonSerializable
      * the `TrackPackageService`.
      *
      * @param array $apiResponse
+     * @param ShipEngineConfig $config
+     * @throws ClientExceptionInterface
      */
     public function __construct(array $apiResponse, ShipEngineConfig $config)
     {

--- a/src/Model/Package/TrackingEvent.php
+++ b/src/Model/Package/TrackingEvent.php
@@ -6,6 +6,7 @@ use ShipEngine\Util\IsoString;
 
 /**
  * Class TrackingEvent
+ *
  * @package ShipEngine\Model\Package
  */
 final class TrackingEvent implements \JsonSerializable

--- a/src/Model/Package/TrackingQuery.php
+++ b/src/Model/Package/TrackingQuery.php
@@ -32,6 +32,13 @@ final class TrackingQuery implements \JsonSerializable
     }
 
     /**
+     * ```json5
+     * {
+     *  "carrierCode": "fedex",
+     *  "trackingNumber": "abc123"
+     * }
+     * ```
+     *
      * Specify data which should be serialized to JSON
      * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
      */

--- a/src/Service/Carriers/CarrierAccountService.php
+++ b/src/Service/Carriers/CarrierAccountService.php
@@ -2,7 +2,6 @@
 
 namespace ShipEngine\Service\Carriers;
 
-use Psr\Http\Client\ClientExceptionInterface;
 use ShipEngine\Model\Carriers\CarrierAccount;
 use ShipEngine\ShipEngineClient;
 use ShipEngine\ShipEngineConfig;

--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -209,6 +209,8 @@ final class ShipEngineClient
 
 
     /**
+     * Handles the response from ShipEngine API.
+     *
      * @param array $response
      * @return array
      */

--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -83,9 +83,10 @@ final class ShipEngineClient
      */
     private function sendRPCRequest(string $method, ?array $params, ShipEngineConfig $config): array
     {
+        $apiResponse = null;
         for ($retry = 0; $retry <= $config->retries; $retry++) {
             try {
-                return $this->sendRequest($method, $params, $retry, $config);
+                $apiResponse = $this->sendRequest($method, $params, $retry, $config);
             } catch (\RuntimeException $err) {
                 if (($retry < $config->retries) &&
                     $err instanceof RateLimitExceededException &&
@@ -99,6 +100,7 @@ final class ShipEngineClient
                 }
             }
         }
+        return $apiResponse;
     }
 
     /**
@@ -199,7 +201,7 @@ final class ShipEngineClient
         );
 
         $assert->isResponse404($statusCode, $parsedResponse);
-        $assert->isResponse429($statusCode, $parsedResponse);
+        $assert->isResponse429($statusCode, $parsedResponse, $config);
         $assert->isResponse500($statusCode, $parsedResponse);
 
         return $this->handleResponse($parsedResponse);

--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -25,7 +25,6 @@ use ShipEngine\Util\Constants\ErrorCode;
 use ShipEngine\Util\Constants\ErrorSource;
 use ShipEngine\Util\Constants\ErrorType;
 use ShipEngine\Util\VersionInfo;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * A wrapped `JSON-RPC 2.0` HTTP client to send HTTP requests from the SDK.
@@ -65,10 +64,10 @@ final class ShipEngineClient
      * @param string $method The RPC method to be used in the request.
      * @param ShipEngineConfig $config A ShipEngineConfig object.
      * @param array|null $params An array of params to be sent in the JSON-RPC request.
-     * @return array|mixed
+     * @return array
      * @throws ClientExceptionInterface
      */
-    public function request(string $method, ShipEngineConfig $config, array $params = null)
+    public function request(string $method, ShipEngineConfig $config, array $params = null): array
     {
         return $this->sendRPCRequest($method, $params, $config);
     }
@@ -79,10 +78,10 @@ final class ShipEngineClient
      * @param string $method
      * @param array|null $params
      * @param ShipEngineConfig $config
-     * @return mixed
+     * @return array
      * @throws GuzzleException
      */
-    private function sendRPCRequest(string $method, ?array $params, ShipEngineConfig $config)
+    private function sendRPCRequest(string $method, ?array $params, ShipEngineConfig $config): array
     {
         for ($retry = 0; $retry <= $config->retries; $retry++) {
             try {
@@ -110,7 +109,7 @@ final class ShipEngineClient
      * @param array|null $params
      * @param int $retry
      * @param ShipEngineConfig $config
-     * @return mixed
+     * @return array
      * @throws GuzzleException
      */
     private function sendRequest(
@@ -118,11 +117,9 @@ final class ShipEngineClient
         ?array $params,
         int $retry,
         ShipEngineConfig $config
-    ) {
+    ): array {
         $assert = new Assert();
         $baseUri = !getenv('CLIENT_BASE_URI') ? $config->baseUrl : getenv('CLIENT_BASE_URI');
-//        $dispatcher = new EventDispatcher();
-//        $shipengineEventListener = $config->eventListener;
         $requestHeaders = array(
             'Api-Key' => $config->apiKey,
             'User-Agent' => $this->deriveUserAgent(),
@@ -213,7 +210,7 @@ final class ShipEngineClient
      * @param array $response
      * @return array
      */
-    private function handleResponse(array $response)
+    private function handleResponse(array $response): array
     {
         if (isset($response['result']) === true) {
             return $response;

--- a/src/ShipEngineConfig.php
+++ b/src/ShipEngineConfig.php
@@ -8,18 +8,75 @@ use ShipEngine\Message\ValidationException;
 use ShipEngine\Util\Assert;
 use ShipEngine\Util\Constants\Endpoints;
 
+/**
+ * Class ShipEngineConfig - This is the configuration object for the ShipEngine object and it's properties are
+ * used throughout this SDK>
+ *
+ * @package ShipEngine
+ */
 final class ShipEngineConfig implements \JsonSerializable
 {
+    /**
+     * The default base uri for the ShipEngineClient.
+     */
     public const DEFAULT_BASE_URI = Endpoints::SHIPENGINE_RPC_URL;
+
+    /**
+     * Default page size for responses from ShipEngine API.
+     */
     public const DEFAULT_PAGE_SIZE = 50;
+
+    /**
+     * Default number of retries the ShipEngineClient should make before returning an exception.
+     */
     public const DEFAULT_RETRIES = 1;
+
+    /**
+     * Default timeout for the ShipEngineClient in seconds as a **DateInterval**.
+     */
     public const DEFAULT_TIMEOUT = 'PT5S';
 
+
+    /**
+     * A ShipEngine API Key, sandbox API Keys start with **TEST_**.
+     *
+     * @var string
+     */
     public string $apiKey;
+
+    /**
+     * The configured base uri for the ShipEngineClient.
+     *
+     * @var string
+     */
     public string $baseUrl;
+
+    /**
+     * Configured page size for responses from ShipEngine API.
+     *
+     * @var int
+     */
     public int $pageSize;
+
+    /**
+     * Configured number of retries the ShipEngineClient should make before returning an exception.
+     *
+     * @var int
+     */
     public int $retries;
+
+    /**
+     * Configured timeout for the ShipEngineClient in seconds as a **DateInterval**.
+     *
+     * @var DateInterval
+     */
     public DateInterval $timeout;
+
+    /**
+     * Configured **PSR-14** event listener to consume events emitted by this SDK.
+     *
+     * @var object|ShipEngineEventListener
+     */
     public $eventListener;
 
     /**
@@ -72,6 +129,12 @@ final class ShipEngineConfig implements \JsonSerializable
         $this->pageSize = $config['pageSize'] ?? self::DEFAULT_PAGE_SIZE;
     }
 
+    /**
+     * Merge in method level config into the global config used by the **ShipEngine** object.
+     *
+     * @param array|null $newConfig
+     * @return $this
+     */
     public function merge(?array $newConfig = null): ShipEngineConfig
     {
         if (!isset($newConfig)) {

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -301,7 +301,7 @@ final class Assert
     {
         if (array_key_exists('error', $response)) {
             $error = $response['error'];
-            $retryAfter = $error['data']['retryAfter'];
+            $retryAfter = isset($error['data']['retryAfter']) ? $error['data']['retryAfter'] : null;
 
             if ($retryAfter > $config->timeout->s) {
                 throw new TimeoutException(

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -299,23 +299,25 @@ final class Assert
 
     public function isResponse429(int $statusCode, array $response, ShipEngineConfig $config): void
     {
-        $error = isset($response['error']) ? $response['error'] : null;
-        $retryAfter = $error['data']['retryAfter'];
+        if (array_key_exists('error', $response)) {
+            $error = $response['error'];
+            $retryAfter = $error['data']['retryAfter'];
 
-        if ($retryAfter > $config->timeout->s) {
-            throw new TimeoutException(
-                $config->timeout->s,
-                ErrorSource::SHIPENGINE,
-                $response['id']
-            );
-        }
+            if ($retryAfter > $config->timeout->s) {
+                throw new TimeoutException(
+                    $config->timeout->s,
+                    ErrorSource::SHIPENGINE,
+                    $response['id']
+                );
+            }
 
-        if ($statusCode === 429) {
-            throw new RateLimitExceededException(
-                new \DateInterval("PT{$retryAfter}S"),
-                ErrorSource::SHIPENGINE,
-                $response['id']
-            );
+            if ($statusCode === 429) {
+                throw new RateLimitExceededException(
+                    new \DateInterval("PT{$retryAfter}S"),
+                    ErrorSource::SHIPENGINE,
+                    $response['id']
+                );
+            }
         }
     }
 }

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -299,7 +299,7 @@ final class Assert
 
     public function isResponse429(int $statusCode, array $response, ShipEngineConfig $config): void
     {
-        $error = $response['error'] ?? null;
+        $error = array_key_exists('error', $response) ? $response['error'] : null;
         $retryAfter = $error['data']['retryAfter'];
 
         if ($retryAfter > $config->timeout->s) {

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -299,7 +299,7 @@ final class Assert
 
     public function isResponse429(int $statusCode, array $response, ShipEngineConfig $config): void
     {
-        $error = $response['error'];
+        $error = $response['error'] ?? null;
         $retryAfter = $error['data']['retryAfter'];
 
         if ($retryAfter > $config->timeout->s) {

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -299,7 +299,7 @@ final class Assert
 
     public function isResponse429(int $statusCode, array $response, ShipEngineConfig $config): void
     {
-        $error = array_key_exists('error', $response) ? $response['error'] : null;
+        $error = isset($response['error']) ? $response['error'] : null;
         $retryAfter = $error['data']['retryAfter'];
 
         if ($retryAfter > $config->timeout->s) {

--- a/src/Util/Assert.php
+++ b/src/Util/Assert.php
@@ -3,6 +3,7 @@
 namespace ShipEngine\Util;
 
 use DateInterval;
+use ShipEngine\Message\RateLimitExceededException;
 use ShipEngine\Message\ShipEngineException;
 use ShipEngine\Message\SystemException;
 use ShipEngine\Message\ValidationException;
@@ -176,13 +177,14 @@ final class Assert
         }
     }
 
+
     /**
      * Asserts that the status code is 500, and if it is a `SystemException` is thrown.
      *
-     * @param array $parsedResponse
      * @param int $statusCode
+     * @param array $parsedResponse
      */
-    public function doesResponseHave500Error(array $parsedResponse, int $statusCode): void
+    public function isResponse500(int $statusCode, array $parsedResponse): void
     {
         if ($statusCode === 500) {
             $error = $parsedResponse['error'];
@@ -290,6 +292,19 @@ final class Assert
                     null
                 );
             }
+        }
+    }
+
+    public function isResponse429(int $statusCode, array $response): void
+    {
+        $error = $response['error'];
+        if ($statusCode === 429) {
+            $retryAfter = $error['data']['retryAfter'];
+            throw new RateLimitExceededException(
+                new \DateInterval("PT{$retryAfter}S"),
+                ErrorSource::SHIPENGINE,
+                $response['id']
+            );
         }
     }
 }

--- a/src/Util/ShipEngineLogger.php
+++ b/src/Util/ShipEngineLogger.php
@@ -8,6 +8,7 @@ use Psr\Log\LogLevel;
 
 /**
  * Class ShipEngineLogger
+ *
  * @package ShipEngine\Util
  */
 final class ShipEngineLogger implements LoggerInterface

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -57,7 +57,7 @@ final class RequestSentEventTest extends MockeryTestCase
      */
     public function testRequestSentEvent(): void
     {
-        $config = $this->testConfig($this->spy);
+        $config = $this->testConfig($this->spy, 0);
         $shipengine = new ShipEngine($config);
         $goodAddress = $this->goodAddress();
 
@@ -87,7 +87,7 @@ final class RequestSentEventTest extends MockeryTestCase
      */
     public function testRequestSentEventOnRetries(): void
     {
-        $config = $this->testConfig($this->spy);
+        $config = $this->testConfig($this->spy, 1);
         $shipengine = new ShipEngine($config);
 
         $eventResult = array();
@@ -227,13 +227,16 @@ final class RequestSentEventTest extends MockeryTestCase
      * in the **testRequestSentEvent()** test.
      *
      * @param object $eventListener
+     * @param int $retries
      * @return array
      */
-    private function testConfig(object $eventListener): array
+    private function testConfig(object $eventListener, int $retries): array
     {
         return array(
             'apiKey' => 'baz',
             'baseUrl' => Endpoints::TEST_RPC_URL,
+            'pageSize' => 75,
+            'retries' => $retries,
             'timeout' => new DateInterval('PT15S'),
             'eventListener' => $eventListener
         );

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -78,7 +78,7 @@ final class RequestSentEventTest extends MockeryTestCase
 
     /**
      * A method using **Mockery Spies** to test the **RequestSentEvent**
-     * being emitted on retries.
+     * being emitted on retries per **JIRA DX-1551**.
      *
      * @throws ClientExceptionInterface
      */
@@ -104,7 +104,7 @@ final class RequestSentEventTest extends MockeryTestCase
     }
 
     /**
-     * Tests the assertions outlined in JIRA DX-1550.
+     * Tests the assertions outlined in **JIRA DX-1550**.
      *
      * @param RequestSentEvent $event
      * @param array $config
@@ -124,7 +124,7 @@ final class RequestSentEventTest extends MockeryTestCase
     }
 
     /**
-     * Tests the assertions outlined in JIRA DX-1553.
+     * Tests the assertions outlined in **JIRA DX-1551**.
      *
      * @param array $events
      * @param array $config
@@ -199,7 +199,7 @@ final class RequestSentEventTest extends MockeryTestCase
 
 
     /**
-     * Fetch a 429 response from the simegnine.
+     * Fetch a 429 response from the **ShipEngine API**.
      *
      * @return Address
      */

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -110,7 +110,7 @@ final class RequestSentEventTest extends MockeryTestCase
         }
     }
 
-    public function testUserAgentInRequestSentEvent()
+    public function testUserAgentInRequestSentEvent(): void
     {
         $config = $this->testConfig($this->spy, 0);
         $shipengine = new ShipEngine($config);

--- a/tests/Message/Events/RequestSentEventTest.php
+++ b/tests/Message/Events/RequestSentEventTest.php
@@ -67,8 +67,11 @@ final class RequestSentEventTest extends MockeryTestCase
         $this->spy->shouldHaveReceived('onRequestSent')
             ->withArgs(
                 function ($event) use (&$eventResult) {
-                    $eventResult = $event;
-                    return true;
+                    if ($event instanceof RequestSentEvent) {
+                        $eventResult = $event;
+                        return true;
+                    }
+                    return false;
                 }
             )->once();
 
@@ -95,8 +98,11 @@ final class RequestSentEventTest extends MockeryTestCase
             $this->spy->shouldHaveReceived('onRequestSent')
                 ->withArgs(
                     function ($event) use (&$eventResult) {
-                        $eventResult[] = $event;
-                        return true;
+                        if ($event instanceof RequestSentEvent) {
+                            $eventResult[] = $event;
+                            return true;
+                        }
+                        return false;
                     }
                 )->twice();
             $this->assertRequestSentEventOnRetries($eventResult, $config);

--- a/tests/Message/Events/ResponseReceivedEventTest.php
+++ b/tests/Message/Events/ResponseReceivedEventTest.php
@@ -67,8 +67,11 @@ final class ResponseReceivedEventTest extends MockeryTestCase
         $this->spy->shouldHaveReceived('onResponseReceived')
             ->withArgs(
                 function ($event) use (&$eventResult) {
-                    $eventResult = $event;
-                    return true;
+                    if ($event instanceof ResponseReceivedEvent) {
+                        $eventResult = $event;
+                        return true;
+                    }
+                    return false;
                 }
             )->once();
         $this->assertResponseReceivedEvent($eventResult, $testStartTime, $config, '200', 0);
@@ -94,8 +97,11 @@ final class ResponseReceivedEventTest extends MockeryTestCase
             $this->spy->shouldHaveReceived('onResponseReceived')
                 ->withArgs(
                     function ($event) use (&$eventResult) {
-                        $eventResult[] = $event;
-                        return true;
+                        if ($event instanceof ResponseReceivedEvent) {
+                            $eventResult[] = $event;
+                            return true;
+                        }
+                        return false;
                     }
                 )->twice();
             $this->assertResponseReceivedEvent($eventResult[0], $testStartTime, $config, '429', 0);

--- a/tests/Message/Events/ResponseReceivedEventTest.php
+++ b/tests/Message/Events/ResponseReceivedEventTest.php
@@ -58,7 +58,7 @@ final class ResponseReceivedEventTest extends MockeryTestCase
     public function testResponseReceivedEvent(): void
     {
         $testStartTime = new DateTime();
-        $config = $this->testConfig($this->spy);
+        $config = $this->testConfig($this->spy, 0);
         $shipengine = new ShipEngine($config);
 
         $shipengine->validateAddress($this->testAddress());
@@ -86,7 +86,7 @@ final class ResponseReceivedEventTest extends MockeryTestCase
     public function testResponseReceivedOnError(): void
     {
         $testStartTime = new DateTime();
-        $config = $this->testConfig($this->spy);
+        $config = $this->testConfig($this->spy, 1);
         $shipengine = new ShipEngine($config);
 
         $eventResult = array();
@@ -194,15 +194,16 @@ final class ResponseReceivedEventTest extends MockeryTestCase
      * in the **testResponseReceivedEvent()** test.
      *
      * @param object $eventListener
+     * @param int $retries
      * @return array
      */
-    private function testConfig(object $eventListener): array
+    private function testConfig(object $eventListener, int $retries): array
     {
         return array(
             'apiKey' => 'baz',
             'baseUrl' => Endpoints::TEST_RPC_URL,
             'pageSize' => 75,
-            'retries' => 1,
+            'retries' => $retries,
             'timeout' => new DateInterval('PT15S'),
             'eventListener' => $eventListener
         );

--- a/tests/Service/Address/AddressServiceTest.php
+++ b/tests/Service/Address/AddressServiceTest.php
@@ -34,8 +34,6 @@ use ShipEngine\Util\Constants\ErrorType;
  * @covers \ShipEngine\ShipEngineClient
  * @covers \ShipEngine\Message\ValidationException
  * @covers \ShipEngine\Message\ShipEngineException
- * @backupStaticAttributes enabled
- * @runTestsInSeparateProcesses
  */
 final class AddressServiceTest extends TestCase
 {
@@ -58,7 +56,7 @@ final class AddressServiceTest extends TestCase
                 'baseUrl' => Endpoints::TEST_RPC_URL,
                 'pageSize' => 75,
                 'retries' => 1,
-                'timeout' => new DateInterval('PT15000S')
+                'timeout' => new DateInterval('PT15S')
             )
         );
     }

--- a/tests/Service/Address/AddressServiceTest.php
+++ b/tests/Service/Address/AddressServiceTest.php
@@ -20,10 +20,6 @@ use ShipEngine\Util\Constants\ErrorType;
 /**
  * Tests the method provided in the `AddressService` that allows for single address validation.
  *
- * @covers \ShipEngine\Util\VersionInfo
- * @covers \ShipEngine\Message\Events\ResponseReceivedEvent
- * @covers \ShipEngine\Message\Events\RequestSentEvent
- * @covers \ShipEngine\Message\Events\ShipEngineEvent
  * @covers \ShipEngine\Util\Assert
  * @covers \ShipEngine\Service\Address\AddressService
  * @covers \ShipEngine\Model\Address\Address
@@ -34,6 +30,14 @@ use ShipEngine\Util\Constants\ErrorType;
  * @covers \ShipEngine\ShipEngineClient
  * @covers \ShipEngine\Message\ValidationException
  * @covers \ShipEngine\Message\ShipEngineException
+ * @uses   \ShipEngine\Message\Events\ShipEngineEvent
+ * @uses   \ShipEngine\Message\Events\ShipEngineEventListener
+ * @uses   \ShipEngine\Message\Events\EventMessage
+ * @uses   \ShipEngine\Message\Events\EventOptions
+ * @uses   \ShipEngine\Util\VersionInfo
+ * @uses   \ShipEngine\Message\Events\ResponseReceivedEvent
+ * @uses   \ShipEngine\Message\Events\RequestSentEvent
+ * @uses   \ShipEngine\Message\Events\ShipEngineEvent
  */
 final class AddressServiceTest extends TestCase
 {
@@ -1162,7 +1166,7 @@ EOT,
         $this->assertInstanceOf(Address::class, $validation->normalizedAddress);
         $this->assertNotEmpty($validation->normalizedAddress);
         $this->assertEquals(
-            $canadaAddress->street[0] . " ". $canadaAddress->street[1],
+            $canadaAddress->street[0] . " " . $canadaAddress->street[1],
             $validation->normalizedAddress->street[0]
         );
         $this->assertEquals(

--- a/tests/Service/Carriers/CarrierAccountServiceTest.php
+++ b/tests/Service/Carriers/CarrierAccountServiceTest.php
@@ -29,6 +29,8 @@ use ShipEngine\Util\Constants\ErrorType;
  * @covers \ShipEngine\Message\Events\ShipEngineEventListener
  * @covers \ShipEngine\Message\Events\RequestSentEvent
  * @covers \ShipEngine\Message\Events\ResponseReceivedEvent
+ * @uses   \ShipEngine\Message\Events\EventMessage
+ * @uses   \ShipEngine\Message\Events\EventOptions
  */
 final class CarrierAccountServiceTest extends TestCase
 {
@@ -57,7 +59,7 @@ final class CarrierAccountServiceTest extends TestCase
         }
     }
 
-    public function testFetchWithMultipleAccounts()
+    public function testFetchWithMultipleAccounts(): void
     {
         $carrier_accounts = self::$shipengine->getCarrierAccounts();
 
@@ -78,7 +80,7 @@ final class CarrierAccountServiceTest extends TestCase
         }
     }
 
-    public function testFetchWithMutlipleAccountsOfSameCarrier()
+    public function testFetchWithMultipleAccountsOfSameCarrier(): void
     {
         $carrier_accounts = self::$shipengine->getCarrierAccounts();
 

--- a/tests/Service/Carriers/CarrierAccountServiceTest.php
+++ b/tests/Service/Carriers/CarrierAccountServiceTest.php
@@ -44,7 +44,7 @@ final class CarrierAccountServiceTest extends TestCase
                 'baseUrl' => Endpoints::TEST_RPC_URL,
                 'pageSize' => 75,
                 'retries' => 1,
-                'timeout' => new DateInterval('PT15000S')
+                'timeout' => new DateInterval('PT15S')
             )
         );
     }

--- a/tests/Service/Package/TrackPackageServiceTest.php
+++ b/tests/Service/Package/TrackPackageServiceTest.php
@@ -36,7 +36,9 @@ use ShipEngine\Util\Constants\ErrorType;
  * @covers \ShipEngine\Util\IsoString
  * @covers \ShipEngine\Util\VersionInfo
  * @covers \ShipEngine\Model\Package\Location
- * @uses \ShipEngine\Message\ShipEngineException
+ * @uses   \ShipEngine\Message\ShipEngineException
+ * @uses   \ShipEngine\Message\Events\EventMessage
+ * @uses   \ShipEngine\Message\Events\EventOptions
  */
 final class TrackPackageServiceTest extends TestCase
 {
@@ -224,7 +226,7 @@ final class TrackPackageServiceTest extends TestCase
         $this->assertEquals('delivered', $trackingResult->events[8]->status);
     }
 
-    public function testDeliveryWithSignuatureTrackingEvent()
+    public function testDeliveryWithSignuatureTrackingEvent(): void
     {
         $trackingResult = self::$shipengine->trackPackage('pkg_1FedexDeLivered');
         $this->trackPackageAssertions($trackingResult);
@@ -241,7 +243,7 @@ final class TrackPackageServiceTest extends TestCase
         $this->assertIsString($trackingResult->events[4]->signer);
     }
 
-    public function testDeliveredAfterMultipleAttempts()
+    public function testDeliveredAfterMultipleAttempts(): void
     {
         $trackingResult = self::$shipengine->trackPackage('pkg_1FedexDeLiveredAttempted');
 
@@ -259,7 +261,7 @@ final class TrackPackageServiceTest extends TestCase
         );
     }
 
-    public function testDeliveredAfterExceptionTrackingEvent()
+    public function testDeliveredAfterExceptionTrackingEvent(): void
     {
         $trackingResult = self::$shipengine->trackPackage('pkg_1FedexDeLiveredException');
 
@@ -275,7 +277,7 @@ final class TrackPackageServiceTest extends TestCase
         );
     }
 
-    public function testSignleExceptionTrackingEvent()
+    public function testSignleExceptionTrackingEvent(): void
     {
         $trackingResult = self::$shipengine->trackPackage('pkg_1FedexException');
 
@@ -336,7 +338,7 @@ final class TrackPackageServiceTest extends TestCase
         $this->assertNotNull($trackingResult->events[2]->location->longitude);
     }
 
-    public function testCarrierDateTimeWithoutTimezome()
+    public function testCarrierDateTimeWithoutTimezone(): void
     {
         $trackingResult = self::$shipengine->trackPackage('pkg_Attempted');
 
@@ -371,7 +373,7 @@ final class TrackPackageServiceTest extends TestCase
         $this->assertTrue($estimatedDelivery->hasTimezone());
     }
 
-    public function doesDeliveryDateMatch(TrackPackageResult $trackingResult)
+    public function doesDeliveryDateMatch(TrackPackageResult $trackingResult): void
     {
         $this->assertEquals(
             $trackingResult->shipment->actualDeliveryDate,
@@ -379,7 +381,7 @@ final class TrackPackageServiceTest extends TestCase
         );
     }
 
-    public function assertEventsInOrder(array $events)
+    public function assertEventsInOrder(array $events): void
     {
         $previousDateTime = $events[0]->dateTime;
         foreach ($events as $event) {

--- a/tests/Service/Package/TrackPackageServiceTest.php
+++ b/tests/Service/Package/TrackPackageServiceTest.php
@@ -52,7 +52,7 @@ final class TrackPackageServiceTest extends TestCase
                 'baseUrl' => Endpoints::TEST_RPC_URL,
                 'pageSize' => 75,
                 'retries' => 1,
-                'timeout' => new DateInterval('PT15000S')
+                'timeout' => new DateInterval('PT15S')
             )
         );
     }

--- a/tests/Service/Package/TrackPackageServiceTest.php
+++ b/tests/Service/Package/TrackPackageServiceTest.php
@@ -4,7 +4,6 @@ namespace Service\Package;
 
 use DateInterval;
 use PHPUnit\Framework\TestCase;
-use ShipEngine\Message\BusinessRuleException;
 use ShipEngine\Message\ShipEngineException;
 use ShipEngine\Message\SystemException;
 use ShipEngine\Message\ValidationException;

--- a/tests/ShipEngineClientTest.php
+++ b/tests/ShipEngineClientTest.php
@@ -1,10 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace Service;
+namespace ShipEngine;
 
 use PHPUnit\Framework\TestCase;
-use ShipEngine\ShipEngineClient;
-use ShipEngine\ShipEngineConfig;
 use ShipEngine\Util\Constants\RPCMethods;
 
 /**

--- a/tests/ShipEngineConfigTest.php
+++ b/tests/ShipEngineConfigTest.php
@@ -2,6 +2,8 @@
 
 namespace ShipEngine;
 
+use DateInterval;
+use DateTime;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use ShipEngine\Message\Events\RequestSentEvent;
@@ -56,7 +58,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -66,7 +68,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -94,7 +96,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => 7,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'events' => null
                 )
             );
@@ -121,7 +123,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => 7,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'events' => null
                 )
             );
@@ -148,7 +150,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => -7,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'events' => null
                 )
             );
@@ -175,7 +177,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => 7,
-                    'timeout' => new \DateInterval('PT0S'),
+                    'timeout' => new DateInterval('PT0S'),
                     'events' => null
                 )
             );
@@ -232,7 +234,7 @@ final class ShipEngineConfigTest extends TestCase
     public function testInvalidTimeoutInMethodCall(): void
     {
         try {
-            $di = new \DateInterval('PT7S');
+            $di = new DateInterval('PT7S');
             $di->invert = 1;
             self::$shipengine->validateAddress(self::$goodAddress, array('timeout' => $di));
         } catch (ValidationException $e) {
@@ -262,7 +264,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -279,7 +281,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -296,7 +298,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -313,7 +315,7 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
@@ -330,11 +332,11 @@ final class ShipEngineConfigTest extends TestCase
                 'baseUrl' => self::$test_url,
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15S'),
+                'timeout' => new DateInterval('PT15S'),
                 'events' => null
             )
         );
-        $update_config = array('timeout' => new \DateInterval('PT25S'));
+        $update_config = array('timeout' => new DateInterval('PT25S'));
         $new_config = $config->merge($update_config);
         $this->assertEquals($update_config['timeout'], $new_config->timeout);
     }
@@ -360,7 +362,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => 0,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'eventListener' => $spy
                 )
             );
@@ -416,7 +418,7 @@ final class ShipEngineConfigTest extends TestCase
                     'apiKey' => 'baz',
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'eventListener' => $spy
                 )
             );
@@ -476,7 +478,7 @@ final class ShipEngineConfigTest extends TestCase
                     'baseUrl' => self::$test_url,
                     'pageSize' => 75,
                     'retries' => 3,
-                    'timeout' => new \DateInterval('PT15S'),
+                    'timeout' => new DateInterval('PT15S'),
                     'eventListener' => $spy
                 )
             );
@@ -529,7 +531,7 @@ final class ShipEngineConfigTest extends TestCase
             'baseUrl' => self::$test_url,
             'pageSize' => 75,
             'retries' => 0,
-            'timeout' => new \DateInterval('PT2S'),
+            'timeout' => new DateInterval('PT2S'),
             'eventListener' => $spy
         );
 
@@ -576,6 +578,65 @@ final class ShipEngineConfigTest extends TestCase
             $this->assertEquals(0, $eventResult[1]->retry);
             $this->assertEquals($eventResult[0]->retry, $eventResult[1]->retry);
             $this->assertEquals(2, $eventResult[0]->timeout->s);
+        }
+    }
+
+    public function testConfigRetryWaitsCorrectAmountOfTime(): void
+    {
+        $testStartTime = new DateTime();
+        $spy = Mockery::spy('ShipEngineEventListener');
+        $config = array(
+            'apiKey' => 'baz',
+            'baseUrl' => self::$test_url,
+            'pageSize' => 75,
+            'retries' => 1,
+            'timeout' => new DateInterval('PT10S'),
+            'eventListener' => $spy
+        );
+
+        try {
+            $address429 = new Address(
+                array(
+                    'street' => array(
+                        '429 Rate Limit Error'
+                    ),
+                    'cityLocality' => 'Boston',
+                    'stateProvince' => 'MA',
+                    'postalCode' => '02215',
+                    'countryCode' => 'US',
+                )
+            );
+            $shipengine = new ShipEngine($config);
+            $shipengine->validateAddress($address429);
+        } catch (ShipEngineException $err) {
+            $this->assertionsOn429Exception($err, RateLimitExceededException::class);
+
+            $requestEventResult = array();
+            $responseEventResult = array();
+            $spy->shouldHaveReceived('onRequestSent')
+                ->withArgs(
+                    function ($event) use (&$requestEventResult) {
+                        if ($event instanceof RequestSentEvent) {
+                            $requestEventResult[] = $event;
+                            return true;
+                        }
+                        return false;
+                    }
+                )->twice();
+
+            $spy->shouldHaveReceived('onResponseReceived')
+                ->withArgs(
+                    function ($event) use (&$responseEventResult) {
+                        if ($event instanceof ResponseReceivedEvent) {
+                            $responseEventResult[] = $event;
+                            return true;
+                        }
+                        return false;
+                    }
+                )->twice();
+
+            $this->assertEqualsWithDelta($testStartTime, new DateTime(), 5);
+            $this->assertEqualsWithDelta($requestEventResult[0]->timestamp, $requestEventResult[1]->timestamp, 5);
         }
     }
 

--- a/tests/ShipEngineTest.php
+++ b/tests/ShipEngineTest.php
@@ -1,10 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace ShipEngine\Tests;
+namespace ShipEngine;
 
 use PHPUnit\Framework\TestCase;
-use ShipEngine\Model\Address\Address;
-use ShipEngine\ShipEngine;
 
 /**
  * @covers \ShipEngine\ShipEngine
@@ -22,7 +20,7 @@ final class ShipEngineTest extends TestCase
                 'baseUrl' => 'https://api.shipengine.com',
                 'pageSize' => 75,
                 'retries' => 7,
-                'timeout' => new \DateInterval('PT15000S'),
+                'timeout' => new \DateInterval('PT15S'),
                 'events' => null
             )
         );


### PR DESCRIPTION
This PR contains the completed tests for `ShipEngineConfig`, `Retries`, including the previously blocked `RequestSentEvent` and `ResponseReceivedEvents` tests respectively.

**JIRAs covered**:
- DX-1551
- DX-1553
- DX-1556
- DX-1557
- DX-1558
- DX-1559
- DX-1560
- DX-1197
- DX-1195
- DX-1198